### PR TITLE
added attributes / inputs to support left/right sidebar

### DIFF
--- a/dist/components/sidebar.component.d.ts
+++ b/dist/components/sidebar.component.d.ts
@@ -4,6 +4,8 @@ export declare class SidebarComponent implements AfterViewInit, OnDestroy {
     private elementRef;
     private sidebar;
     id: String;
+    sidebarClass: String;
+    position: String;
     constructor(elementRef: ElementRef, sidebar: Sidebar);
     selector: string;
     ngAfterViewInit(): void;

--- a/dist/components/sidebar.component.js
+++ b/dist/components/sidebar.component.js
@@ -15,6 +15,8 @@ var SidebarComponent = (function () {
     function SidebarComponent(elementRef, sidebar) {
         this.elementRef = elementRef;
         this.sidebar = sidebar;
+        this.sidebarClass = 'sidebar-dark bg-primary';
+        this.position = 'left';
     }
     Object.defineProperty(SidebarComponent.prototype, "selector", {
         get: function () {
@@ -33,10 +35,18 @@ var SidebarComponent = (function () {
         core_1.Input('sidebar-id'), 
         __metadata('design:type', String)
     ], SidebarComponent.prototype, "id", void 0);
+    __decorate([
+        core_1.Input('sidebar-class'), 
+        __metadata('design:type', String)
+    ], SidebarComponent.prototype, "sidebarClass", void 0);
+    __decorate([
+        core_1.Input('sidebar-position'), 
+        __metadata('design:type', String)
+    ], SidebarComponent.prototype, "position", void 0);
     SidebarComponent = __decorate([
         core_1.Component({
             selector: 'ng2-bl-sidebar',
-            template: "\n\t\t<div class=\"sidebar sidebar-dark bg-primary\" [id]=\"id\" ng2-bl-scrollable>\n\t\t\t<ng-content></ng-content>\n\t\t</div>\n\t",
+            template: "\n\t\t<div class=\"sidebar\" [id]=\"id\" [ngClass]=\"sidebarClass\" [attr.data-position]=\"position\" ng2-bl-scrollable>\n\t\t\t<ng-content></ng-content>\n\t\t</div>\n\t",
             directives: [
                 scrollable_directive_1.ScrollableDirective
             ]

--- a/src/components/sidebar.component.ts
+++ b/src/components/sidebar.component.ts
@@ -5,7 +5,7 @@ import { ScrollableDirective } from '../directives/scrollable.directive';
 @Component({
 	selector: 'ng2-bl-sidebar',
 	template: `
-		<div class="sidebar sidebar-dark bg-primary" [id]="id" ng2-bl-scrollable>
+		<div class="sidebar" [id]="id" [ngClass]="sidebarClass" [attr.data-position]="position" ng2-bl-scrollable>
 			<ng-content></ng-content>
 		</div>
 	`,
@@ -16,6 +16,8 @@ import { ScrollableDirective } from '../directives/scrollable.directive';
 
 export class SidebarComponent implements AfterViewInit, OnDestroy {
 	@Input('sidebar-id') id: String;
+	@Input('sidebar-class') sidebarClass: String = 'sidebar-dark bg-primary';
+	@Input('sidebar-position') position: String = 'left';
 
 	constructor(private elementRef: ElementRef, private sidebar: Sidebar) {}
 


### PR DESCRIPTION
This PR has two changes:
- Adding the 'sidebar-position' attribute will change the location of the sidebar. Binds to 'data-position' on the child div.
- Adding the 'sidebar-class' attribute will change the styling of the sidebar. Uses ngClass and defaults to 'sidebar-dark bg-primary'.

These changes allow styling like this:

``` html
<ng2-bl-sidebar sidebar-id="sidebar" 
                sidebar-position="right" 
                sidebar-class="sidebar-visible-xl-up
                               sidebar-light 
                               bg-white 
                               ls-top-navbar-xs-up">
```

which places the sidebar at the right side of the screen, makes it white, and pushes it below the navbar. The result is that the sidebar has the exact styling of the multiple sidebars preview.
